### PR TITLE
Change steps to use args.diffusion_steps in model_util.py

### DIFF
--- a/utils/model_util.py
+++ b/utils/model_util.py
@@ -52,7 +52,7 @@ def get_model_args(args, data):
 def create_gaussian_diffusion(args):
     # default params
     predict_xstart = True  # we always predict x_start (a.k.a. x0), that's our deal!
-    steps = 1000
+    steps = args.diffusion_steps
     scale_beta = 1.  # no scaling
     timestep_respacing = ''  # can be used for ddim sampling, we don't use it.
     learn_sigma = False


### PR DESCRIPTION
Use the CLI argument `--diffusion_steps` when creating gaussian diffusion instead of fixed `1000` steps. Called by `create_model_and_diffusion`